### PR TITLE
Fix Chat::decode

### DIFF
--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -47,3 +47,29 @@ fn keyboard_markup() {
     assert_eq!(json::encode(&x).unwrap(),
         "{\"force_reply\":true,\"selective\":true}".to_string());
 }
+
+#[test]
+fn decode_group_chat() {
+    use Chat;
+    use GroupChat;
+
+    let blob = r#"{"title":"This is a group chat","id":-12345678}"#;
+    let groupchat: GroupChat = json::decode(&blob).unwrap();
+    let chat: Chat = json::decode(&blob).unwrap();
+
+    assert!(chat.is_group());
+    assert_eq!(Chat::Group(groupchat), chat);
+}
+
+#[test]
+fn decode_user_chat() {
+    use Chat;
+    use User;
+
+    let blob = r#"{"first_name":"test","id":123456789,"username":"test"}"#;
+    let chat: Chat = json::decode(&blob).unwrap();
+    let user: User = json::decode(&blob).unwrap();
+
+    assert!(chat.is_user());
+    assert_eq!(Chat::User(user), chat);
+}


### PR DESCRIPTION
Will now decode `GroupChat`s correctly too. Thanks @neuschaefer for the report #4 and test.