### PR TITLE
Version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ exclude = ["deploy.sh"]
 [dependencies]
 hyper = "*"
 rustc-serialize = "*"
+url = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 
 description = "A library for creating Telegram bots."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 
 description = "A library for creating Telegram bots."

--- a/examples/features.rs
+++ b/examples/features.rs
@@ -14,16 +14,17 @@ fn main() {
     };
 
     // Create bot, test simple API call and print bot information
-    let mut bot = Bot::new(token);
-    println!("getMe: {:?}", bot.get_me());
+    let mut api = Api::new(token);
+    println!("getMe: {:?}", api.get_me());
+    let mut listener = api.listener(ListeningMethod::LongPoll(None));
 
     // Just to demonstrate this method. Sadly, a server listening for updates
     // is not (yet!) integrated in this library.
-    println!("Webhook: {:?}", bot.set_webhook(Some("https://example.com")));
-    println!("Webhook: {:?}", bot.set_webhook::<&str>(None));
+    println!("Webhook: {:?}", api.set_webhook(Some("https://example.com")));
+    println!("Webhook: {:?}", api.set_webhook::<&str>(None));
 
     // Fetch new updates via long poll method
-    let res = bot.long_poll(None, |bot, u| {
+    let res = listener.listen(|u| {
         // If the received update contains a message...
         if let Some(m) = u.message {
             let name = m.from.first_name + &*m.from.last_name
@@ -45,7 +46,7 @@ fn main() {
                     };
 
                     // Reply with custom Keyboard
-                    try!(bot.send_message(
+                    try!(api.send_message(
                         chat_id,
                         format!("Hi, {}!", name),
                         None, None, Some(keyboard.into())));
@@ -58,7 +59,7 @@ fn main() {
 
                     // Send chat action (this is useless here, it's just for
                     // demonstration purposes)
-                    try!(bot.send_chat_action(chat_id, ChatAction::Typing));
+                    try!(api.send_chat_action(chat_id, ChatAction::Typing));
 
                     // Calculate and send the location on the other side of the
                     // earth.
@@ -69,7 +70,7 @@ fn main() {
                         loc.longitude + 180.0
                     };
 
-                    try!(bot.send_location(chat_id, lat, lng, None, None));
+                    try!(api.send_location(chat_id, lat, lng, None, None));
                 },
                 MessageType::Contact(c) => {
                     // Print event
@@ -77,7 +78,7 @@ fn main() {
                         json::encode(&c).unwrap());
 
                     // Just forward the contact back to the sender...
-                    try!(bot.forward_message(chat_id, chat_id, m.message_id));
+                    try!(api.forward_message(chat_id, chat_id, m.message_id));
                 }
                 _ => {}
             }

--- a/examples/features.rs
+++ b/examples/features.rs
@@ -2,19 +2,11 @@ extern crate rustc_serialize;
 extern crate telegram_bot;
 
 use telegram_bot::*;
-use std::env;
 use rustc_serialize::json;
 
 fn main() {
-    // Fetch environment variable with bot token
-    let token = match env::var("TELEGRAM_BOT_TOKEN") {
-        Ok(tok) => tok,
-        Err(e) =>
-            panic!("Environment variable 'TELEGRAM_BOT_TOKEN' missing! {}", e),
-    };
-
     // Create bot, test simple API call and print bot information
-    let mut api = Api::new(token);
+    let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
     println!("getMe: {:?}", api.get_me());
     let mut listener = api.listener(ListeningMethod::LongPoll(None));
 

--- a/examples/features.rs
+++ b/examples/features.rs
@@ -84,7 +84,7 @@ fn main() {
             }
 
         }
-        Ok(())
+        Ok(HandlerResult::Continue)
     });
 
     if let Err(e) = res {

--- a/examples/features.rs
+++ b/examples/features.rs
@@ -76,7 +76,7 @@ fn main() {
             }
 
         }
-        Ok(HandlerResult::Continue)
+        Ok(ListeningAction::Continue)
     });
 
     if let Err(e) = res {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -29,7 +29,7 @@ fn main() {
                     println!("<{}> {}", name, t);
 
                     if t == "/exit" {
-                        return Err(Error::UserInterrupt);
+                        return Ok(HandlerResult::Stop);
                     }
 
                     // Answer message with "Hi"
@@ -43,7 +43,7 @@ fn main() {
         }
 
         // If none of the "try!" statements returned an error: It's Ok!
-        Ok(())
+        Ok(HandlerResult::Continue)
     });
 
     // When the method `long_poll` returns, its due to an error. Check it here.

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -12,11 +12,12 @@ fn main() {
     };
 
     // Create bot, test simple API call and print bot information
-    let mut bot = Bot::new(token);
-    println!("getMe: {:?}", bot.get_me());
+    let mut api = Api::new(token);
+    println!("getMe: {:?}", api.get_me());
+    let mut listener = api.listener(ListeningMethod::LongPoll(None));
 
     // Fetch new updates via long poll method
-    let res = bot.long_poll(None, |bot, u| {
+    let res = listener.listen(|u| {
         // If the received update contains a message...
         if let Some(m) = u.message {
             let name = m.from.first_name;
@@ -32,7 +33,7 @@ fn main() {
                     }
 
                     // Answer message with "Hi"
-                    try!(bot.send_message(
+                    try!(api.send_message(
                         m.chat.id(),
                         format!("Hi, {}! You just wrote '{}'", name, t),
                         None, None, None));

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,18 +1,10 @@
 extern crate telegram_bot;
 
 use telegram_bot::*;
-use std::env;
 
 fn main() {
-    // Fetch environment variable with bot token
-    let token = match env::var("TELEGRAM_BOT_TOKEN") {
-        Ok(tok) => tok,
-        Err(e) =>
-            panic!("Environment variable 'TELEGRAM_BOT_TOKEN' missing! {}", e),
-    };
-
     // Create bot, test simple API call and print bot information
-    let mut api = Api::new(token);
+    let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
     println!("getMe: {:?}", api.get_me());
     let mut listener = api.listener(ListeningMethod::LongPoll(None));
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -21,7 +21,7 @@ fn main() {
                     println!("<{}> {}", name, t);
 
                     if t == "/exit" {
-                        return Ok(HandlerResult::Stop);
+                        return Ok(ListeningAction::Stop);
                     }
 
                     // Answer message with "Hi"
@@ -35,7 +35,7 @@ fn main() {
         }
 
         // If none of the "try!" statements returned an error: It's Ok!
-        Ok(HandlerResult::Continue)
+        Ok(ListeningAction::Continue)
     });
 
     // When the method `long_poll` returns, its due to an error. Check it here.

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,8 +26,8 @@ impl ::std::error::Error for Error {
             Error::Io(ref e) => e.description(),
             Error::JsonDecode(ref e) => e.description(),
             Error::JsonEncode(ref e) => e.description(),
-            Error::Api(ref s) => &*s,
-            Error::InvalidState(ref s) => &*s,
+            Error::Api(ref s) => &s,
+            Error::InvalidState(ref s) => &s,
             Error::UserInterrupt => "user interrupt",
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 use rustc_serialize::json;
+use std::env;
+
 /// Telegram-Bot Result
 pub type Result<T> = ::std::result::Result<T, Error>;
 
@@ -17,6 +19,8 @@ pub enum Error {
     Api(String),
     InvalidState(String),
     UserInterrupt,
+    InvalidTokenFormat(::url::ParseError),
+    InvalidEnvironmentVar(env::VarError),
 }
 
 impl ::std::error::Error for Error {
@@ -29,6 +33,8 @@ impl ::std::error::Error for Error {
             Error::Api(ref s) => &s,
             Error::InvalidState(ref s) => &s,
             Error::UserInterrupt => "user interrupt",
+            Error::InvalidTokenFormat(ref e) => e.description(),
+            Error::InvalidEnvironmentVar(ref e) => e.description(),
         }
     }
 }
@@ -43,6 +49,8 @@ impl fmt::Display for Error {
             Error::Api(ref s) => s.fmt(f),
             Error::InvalidState(ref s) => s.fmt(f),
             Error::UserInterrupt => "user interrupt".fmt(f),
+            Error::InvalidTokenFormat(ref e) => e.fmt(f),
+            Error::InvalidEnvironmentVar(ref e) => e.fmt(f),
         }
     }
 }
@@ -61,3 +69,5 @@ from_impl!(::hyper::error::Error, Http);
 from_impl!(::std::io::Error, Io);
 from_impl!(json::DecoderError, JsonDecode);
 from_impl!(json::EncoderError, JsonEncode);
+from_impl!(::url::ParseError, InvalidTokenFormat);
+from_impl!(env::VarError, InvalidEnvironmentVar);

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,10 +16,14 @@ pub enum Error {
     JsonDecode(json::DecoderError),
     /// Error while encoding JSON data
     JsonEncode(json::EncoderError),
+    /// Telegram server reponsded with an error + description
     Api(String),
+    /// This should never happen (it possibly could if the telegram servers
+    /// would respond with garbage)
     InvalidState(String),
-    UserInterrupt,
+    /// Occurs, if the given bot token would not result in a valid request URL.
     InvalidTokenFormat(::url::ParseError),
+    /// The given environment variable could not be fetched.
     InvalidEnvironmentVar(env::VarError),
 }
 
@@ -32,7 +36,6 @@ impl ::std::error::Error for Error {
             Error::JsonEncode(ref e) => e.description(),
             Error::Api(ref s) => &s,
             Error::InvalidState(ref s) => &s,
-            Error::UserInterrupt => "user interrupt",
             Error::InvalidTokenFormat(ref e) => e.description(),
             Error::InvalidEnvironmentVar(ref e) => e.description(),
         }
@@ -48,7 +51,6 @@ impl fmt::Display for Error {
             Error::JsonEncode(ref e) => e.fmt(f),
             Error::Api(ref s) => s.fmt(f),
             Error::InvalidState(ref s) => s.fmt(f),
-            Error::UserInterrupt => "user interrupt".fmt(f),
             Error::InvalidTokenFormat(ref e) => e.fmt(f),
             Error::InvalidEnvironmentVar(ref e) => e.fmt(f),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ impl Api {
     /// However, the function will not check if the given token is a valid
     /// Telegram token. You can call `get_me` to execute a test request.
     pub fn new(token: String) -> Api {
-        let url = match Url::parse(&*format!("{}{}/dummy", API_URL, token)) {
+        let url = match Url::parse(&format!("{}{}/dummy", API_URL, token)) {
             Ok(url) => url,
             Err(e) => panic!("Invalid token! ({})", e),
         };
@@ -229,7 +229,7 @@ impl Api {
         });
 
         // For all (str, String) pairs: Map to (str, str) and append it to URL
-        let it = params.get_params().iter().map(|&(k, ref v)| (k, &**v));
+        let it = params.get_params().into_iter().map(|&(k, ref v)| (k, &**v));
         url.set_query_from_pairs(it);
 
         // Prepare HTTP Request
@@ -243,7 +243,7 @@ impl Api {
         try!(resp.read_to_string(&mut body));
 
         // Try to decode response as JSON representing a Response
-        match try!(json::decode(&*body)) {
+        match try!(json::decode(&body)) {
             // If the response says that there was an error: Return API-Error
             // with the given description.
             Response { ok: false, description: Some(desc), ..} => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,6 @@ pub struct Api {
     client: Client,
 }
 
-/// Errors that may occur while creating an Api object.
-#[derive(Debug)]
-pub enum CreateError {
-    InvalidTokenFormat(url::ParseError),
-    InvalidEnvironmentVar(env::VarError),
-}
-
 impl Api {
     // =======================================================================
     // Constructors
@@ -44,10 +37,10 @@ impl Api {
     /// an `Err` value. However, the function will not check if the given token
     /// is a valid Telegram token. You can call `get_me` to execute a test
     /// request.
-    pub fn from_token(token: &str) -> std::result::Result<Api, CreateError> {
+    pub fn from_token(token: &str) -> Result<Api> {
         let url = match Url::parse(&format!("{}{}/dummy", API_URL, token)) {
             Ok(url) => url,
-            Err(e) => return Err(CreateError::InvalidTokenFormat(e)),
+            Err(e) => return Err(Error::InvalidTokenFormat(e)),
         };
         Ok(Api {
             url: url,
@@ -58,10 +51,10 @@ impl Api {
     /// Will receive the bot token from the environment variable `var` and call
     /// `from_token` with it. Will return an `Err` value, if the environment
     /// var could not be read or the token has an invalid format.
-    pub fn from_env(var: &str) -> std::result::Result<Api, CreateError> {
+    pub fn from_env(var: &str) -> Result<Api> {
         let token = match env::var(var) {
             Ok(tok) => tok,
-            Err(e) => return Err(CreateError::InvalidEnvironmentVar(e)),
+            Err(e) => return Err(Error::InvalidEnvironmentVar(e)),
         };
 
         Self::from_token(&token)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,9 @@
 //! This crate helps writing bots for the messenger Telegram. Here is a
 //! minimalistic example:
 //!
-//! ```
+//! ```no_run
+//! use telegram_bot::*;
+//!
 //! // Create the Api from a bot token saved in a environment variable and
 //! // test an Api-call
 //! let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
@@ -13,8 +15,6 @@
 //! listener.listen(|u| {
 //!     // If the received update contains a message...
 //!     if let Some(m) = u.message {
-//!         let name = m.from.first_name;
-//!
 //!         // ... and it was a text message:
 //!         if let MessageType::Text(_) = m.msg {
 //!             // Answer message with "Hi"
@@ -27,7 +27,7 @@
 //!     }
 //!
 //!     // If none of the "try!" statements returned an error: It's Ok!
-//!     Ok(HandlerResult::Continue)
+//!     Ok(ListeningAction::Continue)
 //! });
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,60 @@
+//! This crate helps writing bots for the messenger Telegram. Here is a
+//! minimalistic example:
+//!
+//! ```
+//! // Create the Api from a bot token saved in a environment variable and
+//! // test an Api-call
+//! let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
+//! println!("getMe: {:?}", api.get_me());
+//! // We want to listen for new updates via LongPoll
+//! let mut listener = api.listener(ListeningMethod::LongPoll(None));
+//!
+//! // Fetch new updates
+//! listener.listen(|u| {
+//!     // If the received update contains a message...
+//!     if let Some(m) = u.message {
+//!         let name = m.from.first_name;
+//!
+//!         // ... and it was a text message:
+//!         if let MessageType::Text(_) = m.msg {
+//!             // Answer message with "Hi"
+//!             try!(api.send_message(
+//!                 m.chat.id(),
+//!                 format!("Hi, {}!", m.from.first_name),
+//!                 None, None, None)
+//!             );
+//!         }
+//!     }
+//!
+//!     // If none of the "try!" statements returned an error: It's Ok!
+//!     Ok(HandlerResult::Continue)
+//! });
+//! ```
+//!
+//! How to use it
+//! -------------
+//!
+//! *Note*: You should be familiar with the
+//! [official HTTP Api](https://core.telegram.org/bots/api) to use this library
+//! effectivly.
+//!
+//! The first step is always to create an `Api` object. You need one `Api` for
+//! every bot (token) you want to control. You can either create it directly
+//! from a token with `from_token` or, since you shouldn't hardcode your token,
+//! a bit easier: From an environment variable with `from_env`.
+//!
+//! The `Api` object has all methods of the Telegram HTTP API, like
+//! `send_message`. For more information see the `Api` struct documentation.
+//!
+//! Next you want to listen for new updates. This is best done via the `listen`
+//! method on the `Listener` type. To obtain a listener, call `listener` on the
+//! `Api` object.
+//!
+//! Examples
+//! --------
+//!
+//! There are two examples in the `examples/` directory in the project's
+//! repository.
 extern crate hyper;
 extern crate rustc_serialize;
 extern crate url;


### PR DESCRIPTION
A new version with some breaking changes.

- `Bot` was renamed to `Api`
- `long_poll` was replaced by the `Listener` type
- `new` was replaced by `from_token` and `from_env`
- Replaced the `UserInterupt` error by `ListeningAction`

Also: Cleanup and documentation improvements.