### PR TITLE
Added multipart support, send files methods and some updates and changes in the API, details in the description :)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,4 @@ exclude = ["deploy.sh"]
 hyper = "*"
 rustc-serialize = "*"
 url = "*"
-
-[dependencies.multipart]
-version = "*"
+multipart = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ exclude = ["deploy.sh"]
 hyper = "*"
 rustc-serialize = "*"
 url = "*"
+
+[dependencies.multipart]
+version = "*"

--- a/README.md
+++ b/README.md
@@ -52,12 +52,10 @@ fn main() {
         Ok(ListeningAction::Continue)
     });
 
-    // When the method `long_poll` returns, its due to an error. Check it here.
     if let Err(e) = res {
         println!("An error occured: {}", e);
     }
 }
-
 ```
 You can find a bigger example in the `examples` folder.
 

--- a/README.md
+++ b/README.md
@@ -18,34 +18,31 @@ use telegram_bot::*;
 
 fn main() {
     // Create bot, test simple API call and print bot information
-    let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
+    let api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
     println!("getMe: {:?}", api.get_me());
     let mut listener = api.listener(ListeningMethod::LongPoll(None));
 
     // Fetch new updates via long poll method
     let res = listener.listen(|u| {
-        // If the received update contains a message...
-        if let Some(m) = u.message {
-            let name = m.from.first_name;
+        let name = u.message.from.first_name;
 
-            // Match message type
-            match m.msg {
-                MessageType::Text(t) => {
-                    // Print received text message to stdout
-                    println!("<{}> {}", name, t);
+        // Match message type
+        match u.message.msg {
+            MessageType::Text(t) => {
+                // Print received text message to stdout
+                println!("<{}> {}", name, t);
 
-                    if t == "/exit" {
-                        return Ok(ListeningAction::Stop);
-                    }
+                if t == "/exit" {
+                    return Ok(ListeningAction::Stop);
+                }
 
-                    // Answer message with "Hi"
-                    try!(api.send_message(
-                        m.chat.id(),
-                        format!("Hi, {}! You just wrote '{}'", name, t),
-                        None, None, None));
-                },
-                _ => {}
-            }
+                // Answer message with "Hi"
+                try!(api.send_message(
+                    u.message.chat.id(),
+                    format!("Hi, {}! You just wrote '{}'", name, t),
+                    None, None, None));
+            },
+            _ => {}
         }
 
         // If none of the "try!" statements returned an error: It's Ok!
@@ -83,6 +80,6 @@ Please submit pull request against the `dev` branch, unless all changes are just
   - [x] "getUserProfilePhotos"
 - [x] "getUpdates" and `long_poll`
 - [ ] "setWebhook" and `listen`
-- [ ] sending files ("sendAudio", "sendDocument", ...)
+- [x] sending files ("sendAudio", "sendDocument", ...)
 - [x] More good documentation and examples
 - [x] Maybe think about multithreading stuff

--- a/README.md
+++ b/README.md
@@ -24,25 +24,28 @@ fn main() {
 
     // Fetch new updates via long poll method
     let res = listener.listen(|u| {
-        let name = u.message.from.first_name;
+        // If the received update contains a message...
+        if let Some(m) = u.message {
+            let name = m.from.first_name;
 
-        // Match message type
-        match u.message.msg {
-            MessageType::Text(t) => {
-                // Print received text message to stdout
-                println!("<{}> {}", name, t);
+            // Match message type
+            match m.msg {
+                MessageType::Text(t) => {
+                    // Print received text message to stdout
+                    println!("<{}> {}", name, t);
 
-                if t == "/exit" {
-                    return Ok(ListeningAction::Stop);
-                }
+                    if t == "/exit" {
+                        return Ok(ListeningAction::Stop);
+                    }
 
-                // Answer message with "Hi"
-                try!(api.send_message(
-                    u.message.chat.id(),
-                    format!("Hi, {}! You just wrote '{}'", name, t),
-                    None, None, None));
-            },
-            _ => {}
+                    // Answer message with "Hi"
+                    try!(api.send_message(
+                        m.chat.id(),
+                        format!("Hi, {}! You just wrote '{}'", name, t),
+                        None, None, None));
+                },
+                _ => {}
+            }
         }
 
         // If none of the "try!" statements returned an error: It's Ok!

--- a/examples/features.rs
+++ b/examples/features.rs
@@ -6,7 +6,7 @@ use rustc_serialize::json;
 
 fn main() {
     // Create bot, test simple API call and print bot information
-    let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
+    let api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
     println!("getMe: {:?}", api.get_me());
     let mut listener = api.listener(ListeningMethod::LongPoll(None));
 
@@ -17,64 +17,59 @@ fn main() {
 
     // Fetch new updates via long poll method
     let res = listener.listen(|u| {
-        // If the received update contains a message...
-        if let Some(m) = u.message {
-            let name = m.from.first_name + &*m.from.last_name
-                .map_or("".to_string(), |mut n| { n.insert(0, ' '); n });
-            let chat_id = m.chat.id();
+        let name = u.message.from.first_name + &*u.message.from.last_name
+            .map_or("".to_string(), |mut n| { n.insert(0, ' '); n });
+        let chat_id = u.message.chat.id();
 
-            // Match message type
-            match m.msg {
-                MessageType::Text(t) => {
-                    // Print received text message to stdout
-                    println!("<{}> {}", name, t);
+        // Match message type
+        match u.message.msg {
+            MessageType::Text(t) => {
+                // Print received text message to stdout
+                println!("<{}> {}", name, t);
 
-                    // Define one time response keyboard
-                    let keyboard = ReplyKeyboardMarkup {
-                        keyboard: vec![vec![t],
-                                       vec!["Yes".into(), "No".into()]],
-                       one_time_keyboard: Some(true),
-                        .. Default::default()
-                    };
+                // Define one time response keyboard
+                let keyboard = ReplyKeyboardMarkup {
+                    keyboard: vec![vec![t],
+                                   vec!["Yes".into(), "No".into()]],
+                    one_time_keyboard: Some(true),
+                    .. Default::default()
+                };
+                // Reply with custom Keyboard
+                try!(api.send_message(
+                    chat_id,
+                    format!("Hi, {}!", name),
+                    None, None, Some(keyboard.into())));
 
-                    // Reply with custom Keyboard
-                    try!(api.send_message(
-                        chat_id,
-                        format!("Hi, {}!", name),
-                        None, None, Some(keyboard.into())));
+            },
+            MessageType::Location(loc) => {
+                // Print event
+                println!("<{}> is here: {}", name,
+                         json::encode(&loc).unwrap());
 
-                },
-                MessageType::Location(loc) => {
-                    // Print event
-                    println!("<{}> is here: {}", name,
-                        json::encode(&loc).unwrap());
+                // Send chat action (this is useless here, it's just for
+                // demonstration purposes)
+                try!(api.send_chat_action(chat_id, ChatAction::Typing));
 
-                    // Send chat action (this is useless here, it's just for
-                    // demonstration purposes)
-                    try!(api.send_chat_action(chat_id, ChatAction::Typing));
+                // Calculate and send the location on the other side of the
+                // earth.
+                let lat = -loc.latitude;
+                let lng = if loc.longitude > 0.0 {
+                    loc.longitude - 180.0
+                } else {
+                    loc.longitude + 180.0
+                };
 
-                    // Calculate and send the location on the other side of the
-                    // earth.
-                    let lat = -loc.latitude;
-                    let lng = if loc.longitude > 0.0 {
-                        loc.longitude - 180.0
-                    } else {
-                        loc.longitude + 180.0
-                    };
+                try!(api.send_location(chat_id, lat, lng, None, None));
+            },
+            MessageType::Contact(c) => {
+                // Print event
+                println!("<{}> send a contact: {}", name,
+                         json::encode(&c).unwrap());
 
-                    try!(api.send_location(chat_id, lat, lng, None, None));
-                },
-                MessageType::Contact(c) => {
-                    // Print event
-                    println!("<{}> send a contact: {}", name,
-                        json::encode(&c).unwrap());
-
-                    // Just forward the contact back to the sender...
-                    try!(api.forward_message(chat_id, chat_id, m.message_id));
-                }
-                _ => {}
+                // Just forward the contact back to the sender...
+                try!(api.forward_message(chat_id, chat_id, u.message.message_id));
             }
-
+            _ => {}
         }
         Ok(ListeningAction::Continue)
     });

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -4,34 +4,31 @@ use telegram_bot::*;
 
 fn main() {
     // Create bot, test simple API call and print bot information
-    let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
+    let api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
     println!("getMe: {:?}", api.get_me());
     let mut listener = api.listener(ListeningMethod::LongPoll(None));
 
     // Fetch new updates via long poll method
     let res = listener.listen(|u| {
-        // If the received update contains a message...
-        if let Some(m) = u.message {
-            let name = m.from.first_name;
+        let name = u.message.from.first_name;
 
-            // Match message type
-            match m.msg {
-                MessageType::Text(t) => {
-                    // Print received text message to stdout
-                    println!("<{}> {}", name, t);
+        // Match message type
+        match u.message.msg {
+            MessageType::Text(t) => {
+                // Print received text message to stdout
+                println!("<{}> {}", name, t);
 
-                    if t == "/exit" {
-                        return Ok(ListeningAction::Stop);
-                    }
+                if t == "/exit" {
+                    return Ok(ListeningAction::Stop);
+                }
 
-                    // Answer message with "Hi"
-                    try!(api.send_message(
-                        m.chat.id(),
-                        format!("Hi, {}! You just wrote '{}'", name, t),
-                        None, None, None));
-                },
-                _ => {}
-            }
+                // Answer message with "Hi"
+                try!(api.send_message(
+                    u.message.chat.id(),
+                    format!("Hi, {}! You just wrote '{}'", name, t),
+                    None, None, None));
+            },
+            _ => {}
         }
 
         // If none of the "try!" statements returned an error: It's Ok!

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -10,25 +10,28 @@ fn main() {
 
     // Fetch new updates via long poll method
     let res = listener.listen(|u| {
-        let name = u.message.from.first_name;
+        // If the received update contains a message...
+        if let Some(m) = u.message {
+            let name = m.from.first_name;
 
-        // Match message type
-        match u.message.msg {
-            MessageType::Text(t) => {
-                // Print received text message to stdout
-                println!("<{}> {}", name, t);
+            // Match message type
+            match m.msg {
+                MessageType::Text(t) => {
+                    // Print received text message to stdout
+                    println!("<{}> {}", name, t);
 
-                if t == "/exit" {
-                    return Ok(ListeningAction::Stop);
-                }
+                    if t == "/exit" {
+                        return Ok(ListeningAction::Stop);
+                    }
 
-                // Answer message with "Hi"
-                try!(api.send_message(
-                    u.message.chat.id(),
-                    format!("Hi, {}! You just wrote '{}'", name, t),
-                    None, None, None));
-            },
-            _ => {}
+                    // Answer message with "Hi"
+                    try!(api.send_message(
+                        m.chat.id(),
+                        format!("Hi, {}! You just wrote '{}'", name, t),
+                        None, None, None));
+                },
+                _ => {}
+            }
         }
 
         // If none of the "try!" statements returned an error: It's Ok!

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -38,7 +38,6 @@ fn main() {
         Ok(ListeningAction::Continue)
     });
 
-    // When the method `long_poll` returns, its due to an error. Check it here.
     if let Err(e) = res {
         println!("An error occured: {}", e);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
     InvalidTokenFormat(::url::ParseError),
     /// The given environment variable could not be fetched.
     InvalidEnvironmentVar(env::VarError),
+    /// The given path is not valid.
+    InvalidPath(String),
 }
 
 impl ::std::error::Error for Error {
@@ -38,6 +40,7 @@ impl ::std::error::Error for Error {
             Error::InvalidState(ref s) => &s,
             Error::InvalidTokenFormat(ref e) => e.description(),
             Error::InvalidEnvironmentVar(ref e) => e.description(),
+            Error::InvalidPath(ref s) => &s,
         }
     }
 }
@@ -53,6 +56,7 @@ impl fmt::Display for Error {
             Error::InvalidState(ref s) => s.fmt(f),
             Error::InvalidTokenFormat(ref e) => e.fmt(f),
             Error::InvalidEnvironmentVar(ref e) => e.fmt(f),
+            Error::InvalidPath(ref s) => s.fmt(f),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,11 @@ impl Api {
     }
 
     /// Corresponds to the `sendPhoto` method of the API.
-    pub fn send_photo(&self, chat_id: Integer, path: String, caption: Option<String>, reply_to_message_id: Option<Integer>, reply_markup: Option<ReplyMarkup>) -> Result<Message> {
+    pub fn send_photo(&self, chat_id: Integer, path: String,
+                      caption: Option<String>,
+                      reply_to_message_id: Option<Integer>,
+                      reply_markup: Option<ReplyMarkup>)
+                      -> Result<Message> {
         // Prepare parameters
         let mut params = Params::new();
         params.add_get("chat_id", chat_id);
@@ -266,7 +270,13 @@ impl Api {
     }
 
     /// Corresponds to the `sendAudio` method of the API.
-    pub fn send_audio(&self, chat_id: Integer, path: String, duration: Option<Integer>, performer: Option<String>, title: Option<String>, reply_to_message_id: Option<Integer>, reply_markup: Option<ReplyMarkup>) -> Result<Message> {
+    pub fn send_audio(&self, chat_id: Integer, path: String,
+                      duration: Option<Integer>,
+                      performer: Option<String>,
+                      title: Option<String>,
+                      reply_to_message_id: Option<Integer>,
+                      reply_markup: Option<ReplyMarkup>)
+                      -> Result<Message> {
         // Prepare parameters
         let mut params = Params::new();
         params.add_get("chat_id", chat_id);
@@ -283,7 +293,11 @@ impl Api {
     }
 
     /// Corresponds to the `sendVoice` method of the API.
-    pub fn send_voice(&self, chat_id: Integer, path: String, duration: Option<Integer>, reply_to_message_id: Option<Integer>, reply_markup: Option<ReplyMarkup>) -> Result<Message> {
+    pub fn send_voice(&self, chat_id: Integer, path: String,
+                      duration: Option<Integer>,
+                      reply_to_message_id: Option<Integer>,
+                      reply_markup: Option<ReplyMarkup>)
+                      -> Result<Message> {
         // Prepare parameters
         let mut params = Params::new();
         params.add_get("chat_id", chat_id);
@@ -299,7 +313,10 @@ impl Api {
 
 
     /// Corresponds to the `sendDocument` method of the API.
-    pub fn send_document(&self, chat_id: Integer, path: String, reply_to_message_id: Option<Integer>, reply_markup: Option<ReplyMarkup>) -> Result<Message> {
+    pub fn send_document(&self, chat_id: Integer, path: String,
+                         reply_to_message_id: Option<Integer>,
+                         reply_markup: Option<ReplyMarkup>)
+                         -> Result<Message> {
         // Prepare parameters
         let mut params = Params::new();
         params.add_get("chat_id", chat_id);
@@ -313,7 +330,10 @@ impl Api {
     }
 
     /// Corresponds to the `sendSticker` method of the API.
-    pub fn send_sticker(&self, chat_id: Integer, path: String, reply_to_message_id: Option<Integer>, reply_markup: Option<ReplyMarkup>) -> Result<Message> {
+    pub fn send_sticker(&self, chat_id: Integer, path: String,
+                        reply_to_message_id: Option<Integer>,
+                        reply_markup: Option<ReplyMarkup>)
+                        -> Result<Message> {
         // Prepare parameters
         let mut params = Params::new();
         params.add_get("chat_id", chat_id);
@@ -327,7 +347,12 @@ impl Api {
     }
 
     /// Corresponds to the `sendVideo` method of the API.
-    pub fn send_video(&self, chat_id: Integer, path: String, caption: Option<String>, duration: Option<Integer>, reply_to_message_id: Option<Integer>, reply_markup: Option<ReplyMarkup>) -> Result<Message> {
+    pub fn send_video(&self, chat_id: Integer, path: String,
+                      caption: Option<String>,
+                      duration: Option<Integer>,
+                      reply_to_message_id: Option<Integer>,
+                      reply_markup: Option<ReplyMarkup>)
+                      -> Result<Message> {
         // Prepare parameters
         let mut params = Params::new();
         params.add_get("chat_id", chat_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,21 +6,24 @@
 //!
 //! // Create the Api from a bot token saved in a environment variable and
 //! // test an Api-call
-//! let mut api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
+//! let api = Api::from_env("TELEGRAM_BOT_TOKEN").unwrap();
 //! println!("getMe: {:?}", api.get_me());
 //! // We want to listen for new updates via LongPoll
 //! let mut listener = api.listener(ListeningMethod::LongPoll(None));
 //!
 //! // Fetch new updates
 //! listener.listen(|u| {
-//!     // if the message was a text message:
-//!     if let MessageType::Text(_) = u.message.msg {
-//!         // Answer message with "Hi"
-//!         try!(api.send_message(
-//!             u.message.chat.id(),
-//!             format!("Hi, {}!", u.message.from.first_name),
-//!             None, None, None)
-//!         );
+//!     // If the received update contains a message...
+//!     if let Some(m) = u.message {
+//!         // if the message was a text message:
+//!         if let MessageType::Text(_) = m.msg {
+//!             // Answer message with "Hi"
+//!             try!(api.send_message(
+//!                 m.chat.id(),
+//!                 format!("Hi, {}!", m.from.first_name),
+//!                 None, None, None)
+//!             );
+//!         }
 //!     }
 //!
 //!     // If none of the "try!" statements returned an error: It's Ok!

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -486,7 +486,7 @@ pub struct Location {
 #[derive(RustcDecodable, Debug, PartialEq, Clone)]
 pub struct Update {
     pub update_id: Integer,
-    pub message: Message
+    pub message: Option<Message>
 }
 
 // impl_encode!(Update, 2,


### PR DESCRIPTION
# Changes

This is a summary with all the changes (I think that I didn't missed any change :smile:  )

## mod.rs

- `try_field` macro: Instead of creating a closure and passing it to Decodable::decode, apply that function directly
- `Response`: Added `error_code: Option<Integer>`, this is a parameter that you get if something went wrong
- `Audio`: Added performer and title, both `Option<String>`, this was added the 15 August in the API
- `Voice`: Added Voice type, this was added the 15 August in the API
- `Message`: The 30 july they made some changes in the Api, this is one of them, adding an optional `caption` field to the Message structure. The 15 August they added the optional `voice` field.
- `MessageType` enum: Changed `Photo(PhotoSize)` for `Photo(Vec<PhotoSize>)` because you receive a list of images, added `Voice(Voice)` because of the 15 August changes.
- `maybe_field` macro: same as try\_field macro
- `impl Decodable for MessageType`: Added the `file` optional field missing and new `voice` optional field, and the same as try_field macro.
- `Document` and `Sticker`: The 30 july they changed the thumb field to be optional
- `Video`: The 30 july they changed the thumb field to be optional and removed the caption field (they moved it to Message)

And the most important to me:
- `Update` struct: Changed `message` field from `Optional<Message>` to just `Message`, because in the API the message is not optional, if you are receiving an Update, it will have a Message for sure, I don't know why you have it Optional :S

## lib.rs

- Initial documentation: Changed the example, because I removed the `Optional` from the message, so you don't have to check it with the `if let Some(m) = u.message {`, if you are there, you know that you have a message for sure.
- `SendPath` enum that is used by the multipart to differentiate sending a local file or a file id, because it's sended differently.
- `RequestType` enum that differentiate between a Post request or a Multipart request encapsulating a `SendPath`
- Implemented `Clone` trait for `Api` struct, I don't know if you like it, but I'm building kind-of framework up to this library and I find it really useful to have the clone implemented ^^
- `&mut self` for `&self`, I changed this because I don't really know why you need mutable reference in the methods, you are not mutating at all, and for what I readed it's better use a reference than a mutable reference, but maybe there are something that I'm missing, maybe you can explain me why you are using &mut self ^^
- All the `send_request` now uses the RequestType
- Implement `send_photo`, `send_audio`, `send_voice`, `send_document`, `send_sticker` and `send_video`, they all accept and String for path, and "detect" if it's a local file or an ID, with the `detect_file_or_id` function, I really love this, but maybe you prefer to accept directly what kind is or some other thing, this is what I do in my Go library, that's why I made it this way :smile:
- `detect_file_or_id` "detect" if a given string is a path or an ID, first check if the string have a dot (the telegram API don't accept files without extension, I saw it testing the API some time ago, and the IDs don't have dots), if have it, see if it's really a file, if it is, return the SendPath::File, and if any of the checks fail, it will return a SendPath::Id. For example, if the path don't exist, but it's not a real file id, it will return a SendPath::Id, and the telegram server will return an error saying that the id is not valid
- `request` dispatch depending of Post or Multipart.
- `multipart_request` do a multipart-form request :smile:
- `post_request` I changed the GET request for a POST request, the main reason is because if you use GET in sendMessage, there are size limit in the GET request and probably can't send a long message, so it's better use POST in sendMessage, and if you use POST in one, is better to use it in everyone.
- Listener: sending the "getUpdate" request now is done using an auxiliar function.

## error.rs

- Added `InvalidPath(String)` error that is used in the `multipart_request` method when trying to access the path of a file and it's not valid.

## examples/*.rs

- I removed the Option in the field message in Update struct, so now there are not need to use `if let Some(m) = u.message {`
- I changed the methods to take `&self` instead of `&mut self`, so now you don't need to declare the api as mutable (`let mut api` for `let api`)

## Cargo.tml

- Added multipart dependency

## README.md

- Checked the "sending files" TODO
