### PR TITLE
Fix handling of replies to a message

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -267,7 +267,7 @@ impl Decodable for Message {
                 chat: try_field!(d, "chat"),
                 date: try_field!(d, "date"),
                 forward: try_field!(d, "forward"),
-                reply: try_field!(d, "reply"),
+                reply: try_field!(d, "reply_to_message"),
                 msg: try!(MessageType::decode(d)),
                 caption: try_field!(d, "caption"),
             })

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -247,8 +247,9 @@ pub struct Message {
     pub chat: Chat,
     pub date: Integer,
 
-    // forward_from and forward_date in one
-    pub forward: Option<(User, Integer)>,
+    // forward_from and forward_date in one is BS
+    pub forward_from: Option<(User)>,
+    pub forward_date: Option<(Integer)>,
     pub reply: Option<Box<Message>>,
 
     pub msg: MessageType,
@@ -266,7 +267,8 @@ impl Decodable for Message {
                 from: try_field!(d, "from"),
                 chat: try_field!(d, "chat"),
                 date: try_field!(d, "date"),
-                forward: try_field!(d, "forward"),
+                forward_from: try_field!(d, "forward_from"),
+                forward_date: try_field!(d, "forward_date"),
                 reply: try_field!(d, "reply_to_message"),
                 msg: try!(MessageType::decode(d)),
                 caption: try_field!(d, "caption"),


### PR DESCRIPTION
This is just to make it work, the field is actually named `reply_to_message`, not `reply`, it'd propably be more useful to change the field's name in the API, too.

Added a fix for `forward`, which didn't get the right values from the API as well, while splitting forward in the original two components. The main reason for this is that it was a quick fix to make my bot work, but with the current state of documentation, I think it's useful to just keep to the original names from the telegram API.