### PR TITLE
Api update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "telegram-bot"
 version = "0.3.0"
-authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
+authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>"]
 
 description = "A library for creating Telegram bots."
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>"]
 
 description = "A library for creating Telegram bots."

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can find a bigger example in the `examples` folder.
 This library is available via `crates.io`. In order to use it, just add this to your `Cargo.toml`:
 
 ```
-telegram-bot = "0.3"
+telegram-bot = "0.4"
 ```
 
 ## Collaboration

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fn main() {
                     try!(api.send_message(
                         m.chat.id(),
                         format!("Hi, {}! You just wrote '{}'", name, t),
-                        None, None, None));
+                        None, None, None, None));
                 },
                 _ => {}
             }

--- a/examples/features.rs
+++ b/examples/features.rs
@@ -41,7 +41,7 @@ fn main() {
                     try!(api.send_message(
                         chat_id,
                         format!("Hi, {}!", name),
-                        None, None, Some(keyboard.into())));
+                        None, None, None, Some(keyboard.into())));
 
                 },
                 MessageType::Location(loc) => {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -28,7 +28,7 @@ fn main() {
                     try!(api.send_message(
                         m.chat.id(),
                         format!("Hi, {}! You just wrote '{}'", name, t),
-                        None, None, None));
+                        None, None, None, None));
                 },
                 _ => {}
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ impl Api {
 
     /// Corresponds to the "sendMessage" method of the API.
     pub fn send_message(&self, chat_id: Integer, text: String,
+                        parse_mode: Option<ParseMode>,
                         disable_web_page_preview: Option<bool>,
                         reply_to_message_id: Option<Integer>,
                         reply_markup: Option<ReplyMarkup>)
@@ -169,6 +170,7 @@ impl Api {
         let mut params = Params::new();
         params.add_get("chat_id", chat_id);
         params.add_get("text", text);
+        params.add_get_opt("parse_mode", parse_mode);
         params.add_get_opt("disable_web_page_preview", disable_web_page_preview);
         params.add_get_opt("reply_to_message_id", reply_to_message_id);
         try!(params.add_get_json_opt("reply_markup", reply_markup));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!             try!(api.send_message(
 //!                 m.chat.id(),
 //!                 format!("Hi, {}!", m.from.first_name),
-//!                 None, None, None)
+//!                 None, None, None, None)
 //!             );
 //!         }
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -531,7 +531,7 @@ impl Api {
         // Change connect("&") to join("&") when rust 1.3 becomes stable
         let bodyparams = p.get_params().into_iter().map(|&(k, ref  v)| {
             format!("{}={}", k, &**v)
-        }).collect::<Vec<_>>().connect("&");
+        }).collect::<Vec<_>>().join("&");
 
         // Create the request with the body and headers
         let req = client

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -596,6 +596,8 @@ pub struct Location {
     pub latitude: Float,
 }
 
+// ---------------------------------------------------------------------------
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct GroupToSuperGroupMigration {
     pub from: Integer,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -232,9 +232,9 @@ impl Chat {
     }
 
     pub fn to_user(&self) -> Option<User> {
-        if let &Chat::Private { ref id, ref first_name, ref last_name, ref username } = self {
+        if let &Chat::Private { id, ref first_name, ref last_name, ref username } = self {
             Some(User {
-                id: *id,
+                id: id,
                 first_name: first_name.clone(),
                 last_name: last_name.clone(),
                 username: username.clone(),
@@ -290,7 +290,7 @@ impl Encodable for Chat {
     fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
 
         match self {
-            &Chat::Private { ref id, ref first_name, ref last_name, ref username } => {
+            &Chat::Private { id, ref first_name, ref last_name, ref username } => {
                 e.emit_struct("Chat", 5, |e| {
                     try!(e.emit_struct_field("id", 0, |e| {
                         id.encode(e)
@@ -310,13 +310,13 @@ impl Encodable for Chat {
                     Ok(())
                 })
             },
-            &Chat::Group { ref id, ref title, ref is_supergroup} => {
+            &Chat::Group { id, ref title, is_supergroup} => {
                 e.emit_struct("Chat", 3, |e| {
                     try!(e.emit_struct_field("id", 0, |e| {
                         id.encode(e)
                     }));
                     try!(e.emit_struct_field("type", 1, |e| {
-                        let typ = if *is_supergroup { "supergroup" } else { "group" };
+                        let typ = if is_supergroup { "supergroup" } else { "group" };
                         typ.encode(e)
                     }));
                     try!(e.emit_struct_field("title", 2, |e| {
@@ -325,7 +325,7 @@ impl Encodable for Chat {
                     Ok(())
                 })
             },
-            &Chat::Channel { ref id, ref title, ref name} => {
+            &Chat::Channel { id, ref title, ref name} => {
                 e.emit_struct("Channel", 3, |e| {
                     try!(e.emit_struct_field("id", 0, |e| {
                         id.encode(e)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -466,6 +466,14 @@ impl Decodable for MessageType {
     }
 }
 
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct GroupToSuperGroupMigration {
+    pub from: Integer,
+    pub to: Integer,
+}
+
 // ===========================================================================
 // Telegram types directly mapped to Rust types
 // ===========================================================================
@@ -595,14 +603,6 @@ impl_encode!(Contact, 4,
 pub struct Location {
     pub longitude: Float,
     pub latitude: Float,
-}
-
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub struct GroupToSuperGroupMigration {
-    pub from: Integer,
-    pub to: Integer,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -392,7 +392,7 @@ impl_encode!(User, 4,
 
 // ---------------------------------------------------------------------------
 /// Telegram type "GroupChat" (directly mapped)
-#[derive(RustcDecodable, RustcEncodable, Debug, PartialEq, Clone)]
+#[derive(RustcEncodable, Debug, PartialEq, Clone)]
 pub struct GroupChat {
     pub id: Integer,
     pub title: String,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -59,8 +59,8 @@ macro_rules! try_field {
 // ===========================================================================
 // Telegram primitive types
 // ===========================================================================
-/// The Telegram "Integer": Currently i32.
-pub type Integer = i32;
+/// The Telegram "Integer": Currently i64.
+pub type Integer = i64;
 /// The Telegram "Float": Currently f32.
 pub type Float = f32;
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -255,7 +255,7 @@ impl Decodable for Chat {
                         name: try_field!(d, "username"),
                     }))
                 }
-                _ => panic!("Not implemented")
+                _ => Err(d.error(&format!("Invalid chat type: {}", typ)))
             }
         })
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,6 +12,7 @@
 
 use rustc_serialize::{Decodable, Encodable, Decoder, Encoder};
 use std::convert::Into;
+use std::fmt;
 
 // ===========================================================================
 // Helpers
@@ -649,6 +650,22 @@ impl_encode!(ReplyKeyboardMarkup, 4,
     [0 => keyboard],
     [1 => resize_keyboard, 2 => one_time_keyboard, 3 => selective]);
 
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ParseMode {
+    Markdown,
+    Html,
+}
+
+impl fmt::Display for ParseMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match *self {
+            ParseMode::Markdown => "Markdown",
+            ParseMode::Html => "HTML",
+        })
+    }
+}
 
 // ===========================================================================
 // Unit tests (mainly encode & decode)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -229,6 +229,17 @@ impl Chat {
     pub fn is_channel(&self) -> bool {
         if let &Chat::Channel {..} = self { true } else { false }
     }
+
+    pub fn to_user(&self) -> Option<User> {
+        if let &Chat::Private { ref id, ref first_name, ref last_name, ref username } = self {
+            Some(User {
+                id: *id,
+                first_name: first_name.clone(),
+                last_name: last_name.clone(),
+                username: username.clone(),
+            })
+        } else { None }
+    }
 }
 
 impl Decodable for Chat {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -392,20 +392,55 @@ impl_encode!(User, 4,
 
 // ---------------------------------------------------------------------------
 /// Telegram type "GroupChat" (directly mapped)
-#[derive(RustcEncodable, Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct GroupChat {
     pub id: Integer,
     pub title: String,
     pub is_supergroup: bool
 }
 
+impl Encodable for GroupChat {
+    fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
+        e.emit_struct("GroupChat", 3, |e| {
+            try!(e.emit_struct_field("id", 0, |e| {
+                self.id.encode(e)
+            }));
+            try!(e.emit_struct_field("title", 1, |e| {
+                self.title.encode(e)
+            }));
+            try!(e.emit_struct_field("type", 2, |e| {
+                let typ = if self.is_supergroup { "supergroup" } else { "group" };
+                typ.encode(e)
+            }));
+            Ok(())
+        })
+    }
+}
+
 // ---------------------------------------------------------------------------
 
-#[derive(RustcDecodable, RustcEncodable, Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Channel {
     pub id: Integer,
     pub title: String,
-    pub name: String,
+    pub name: Option<String>,
+}
+
+impl Encodable for Channel {
+    fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
+        e.emit_struct("Channel", 3, |e| {
+            try!(e.emit_struct_field("id", 0, |e| {
+                self.id.encode(e)
+            }));
+            try!(e.emit_struct_field("title", 1, |e| {
+                self.title.encode(e)
+            }));
+            try!(e.emit_struct_field("name", 2, |e| {
+                self.name.encode(e)
+            }));
+            Ok(())
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -654,7 +654,7 @@ impl_encode!(ReplyKeyboardMarkup, 4,
 
 /// Strongly typed ParseMode. Instead of passing a String to the
 /// `send_message` method, this is used.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ParseMode {
     Markdown,
     Html,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -249,7 +249,7 @@ impl Decodable for Chat {
             let id : Integer = try_field!(d, "id");
             let typ: String = try_field!(d, "type");
 
-            match typ.as_str() {
+            match typ.as_ref() {
                 "private" => {
                     Ok(Chat::Private {
                         id: id,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -652,6 +652,8 @@ impl_encode!(ReplyKeyboardMarkup, 4,
 
 // ---------------------------------------------------------------------------
 
+/// Strongly typed ParseMode. Instead of passing a String to the
+/// `send_message` method, this is used.
 #[derive(Debug, PartialEq, Clone)]
 pub enum ParseMode {
     Markdown,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -460,60 +460,6 @@ impl_encode!(User, 4,
     [0 => id, 1 => first_name],
     [2 => last_name, 3 => username]);
 
-
-// ---------------------------------------------------------------------------
-/// Telegram type "GroupChat" (directly mapped)
-#[derive(Debug, PartialEq, Clone)]
-pub struct GroupChat {
-    pub id: Integer,
-    pub title: String,
-    pub is_supergroup: bool
-}
-
-impl Encodable for GroupChat {
-    fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
-        e.emit_struct("GroupChat", 3, |e| {
-            try!(e.emit_struct_field("id", 0, |e| {
-                self.id.encode(e)
-            }));
-            try!(e.emit_struct_field("title", 1, |e| {
-                self.title.encode(e)
-            }));
-            try!(e.emit_struct_field("type", 2, |e| {
-                let typ = if self.is_supergroup { "supergroup" } else { "group" };
-                typ.encode(e)
-            }));
-            Ok(())
-        })
-    }
-}
-
-// ---------------------------------------------------------------------------
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct Channel {
-    pub id: Integer,
-    pub title: String,
-    pub name: Option<String>,
-}
-
-impl Encodable for Channel {
-    fn encode<E: Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
-        e.emit_struct("Channel", 3, |e| {
-            try!(e.emit_struct_field("id", 0, |e| {
-                self.id.encode(e)
-            }));
-            try!(e.emit_struct_field("title", 1, |e| {
-                self.title.encode(e)
-            }));
-            try!(e.emit_struct_field("name", 2, |e| {
-                self.name.encode(e)
-            }));
-            Ok(())
-        })
-    }
-}
-
 // ---------------------------------------------------------------------------
 /// Telegram type "PhotoSize" (directly mapped)
 #[derive(RustcDecodable, Debug, PartialEq, Clone)]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -401,6 +401,8 @@ pub enum MessageType {
     NewChatPhoto(Vec<PhotoSize>),
     DeleteChatPhoto,
     GroupChatCreated,
+    SuperGroupChatCreated(GroupToSuperGroupMigration),
+    ChannelChatCreated,
 }
 
 impl Decodable for MessageType {
@@ -443,6 +445,19 @@ impl Decodable for MessageType {
         if let Some(true) = try!(d.read_struct_field(
             "group_chat_created", 0, Decodable::decode)) {
             return Ok(MessageType::GroupChatCreated);
+        };
+
+        if let Some(true) = try!(d.read_struct_field(
+            "supergroup_chat_created", 0, Decodable::decode)) {
+            return Ok(MessageType::SuperGroupChatCreated(GroupToSuperGroupMigration {
+                from: try_field!(d, "migrate_from_chat_id"),
+                to: try_field!(d, "migrate_to_chat_id"),
+            }))
+        };
+
+        if let Some(true) = try!(d.read_struct_field(
+            "channel_chat_created", 0, Decodable::decode)) {
+            return Ok(MessageType::ChannelChatCreated);
         };
 
         // None of the tested fields is present: This is an error
@@ -579,6 +594,12 @@ impl_encode!(Contact, 4,
 pub struct Location {
     pub longitude: Float,
     pub latitude: Float,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct GroupToSuperGroupMigration {
+    pub from: Integer,
+    pub to: Integer,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -474,6 +474,24 @@ pub struct GroupToSuperGroupMigration {
     pub to: Integer,
 }
 
+// ---------------------------------------------------------------------------
+/// Strongly typed ParseMode. Instead of passing a String to the
+/// `send_message` method, this is used.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum ParseMode {
+    Markdown,
+    Html,
+}
+
+impl fmt::Display for ParseMode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", match *self {
+            ParseMode::Markdown => "Markdown",
+            ParseMode::Html => "HTML",
+        })
+    }
+}
+
 // ===========================================================================
 // Telegram types directly mapped to Rust types
 // ===========================================================================
@@ -649,25 +667,6 @@ impl Default for ReplyKeyboardMarkup {
 impl_encode!(ReplyKeyboardMarkup, 4,
     [0 => keyboard],
     [1 => resize_keyboard, 2 => one_time_keyboard, 3 => selective]);
-
-// ---------------------------------------------------------------------------
-
-/// Strongly typed ParseMode. Instead of passing a String to the
-/// `send_message` method, this is used.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum ParseMode {
-    Markdown,
-    Html,
-}
-
-impl fmt::Display for ParseMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", match *self {
-            ParseMode::Markdown => "Markdown",
-            ParseMode::Html => "HTML",
-        })
-    }
-}
 
 // ===========================================================================
 // Unit tests (mainly encode & decode)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -179,7 +179,7 @@ impl Encodable for ChatAction {
 }
 
 // ---------------------------------------------------------------------------
-/// Either a User or a GroupChat. Used in "chat" field of Message. Has some
+/// Either a Private or a Group or a Channel. Used in "chat" field of Message. Has some
 /// useful methods for less typing.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Chat {

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -71,7 +71,7 @@ fn decode_user_chat() {
     let user: User = json::decode(&blob).unwrap();
 
     assert!(chat.is_user());
-    assert_eq!(Chat::User(user), chat);
+    assert_eq!(Chat::Private(user), chat);
 }
 
 #[test]

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -91,10 +91,9 @@ fn decode_user_chat() {
 
     let blob = r#"{"first_name":"test","id":123456789,"username":"test","type":"private"}"#;
     let chat: Chat = json::decode(&blob).unwrap();
-    let user: User = json::decode(&blob).unwrap();
+    json::decode::<User>(&blob).unwrap();
 
     assert!(chat.is_user());
-    assert_eq!(Chat::Private(user), chat);
 }
 
 #[test]

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -48,18 +48,14 @@ fn keyboard_markup() {
         r#"{"force_reply":true,"selective":true}"#.to_string());
 }
 
-// #[test]
-// fn decode_group_chat() {
-//     use Chat;
-//     use GroupChat;
+#[test]
+fn decode_group_chat() {
+    use Chat;
 
-//     let blob = r#"{"title":"This is a group chat","id":-12345678,"type":"group"}"#;
-//     let groupchat: GroupChat = json::decode(&blob).unwrap();
-//     let chat: Chat = json::decode(&blob).unwrap();
-
-//     assert!(chat.is_group());
-//     assert_eq!(Chat::Group(groupchat), chat);
-// }
+    let blob = r#"{"title":"This is a group chat","id":-12345678,"type":"group"}"#;
+    let chat: Chat = json::decode(&blob).unwrap();
+    assert!(chat.is_group());
+}
 
 #[test]
 fn decode_user_chat() {

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -48,25 +48,25 @@ fn keyboard_markup() {
         r#"{"force_reply":true,"selective":true}"#.to_string());
 }
 
-#[test]
-fn decode_group_chat() {
-    use Chat;
-    use GroupChat;
+// #[test]
+// fn decode_group_chat() {
+//     use Chat;
+//     use GroupChat;
 
-    let blob = r#"{"title":"This is a group chat","id":-12345678}"#;
-    let groupchat: GroupChat = json::decode(&blob).unwrap();
-    let chat: Chat = json::decode(&blob).unwrap();
+//     let blob = r#"{"title":"This is a group chat","id":-12345678,"type":"group"}"#;
+//     let groupchat: GroupChat = json::decode(&blob).unwrap();
+//     let chat: Chat = json::decode(&blob).unwrap();
 
-    assert!(chat.is_group());
-    assert_eq!(Chat::Group(groupchat), chat);
-}
+//     assert!(chat.is_group());
+//     assert_eq!(Chat::Group(groupchat), chat);
+// }
 
 #[test]
 fn decode_user_chat() {
     use Chat;
     use User;
 
-    let blob = r#"{"first_name":"test","id":123456789,"username":"test"}"#;
+    let blob = r#"{"first_name":"test","id":123456789,"username":"test","type":"private"}"#;
     let chat: Chat = json::decode(&blob).unwrap();
     let user: User = json::decode(&blob).unwrap();
 
@@ -89,7 +89,8 @@ fn decode_update() {
             "message_id" : 74,
             "chat" : {
                 "title" : "This is a group chat",
-                "id" : -12345678
+                "id" : -12345678,
+                "type": "group"
             }
         },
         "update_id" : 123456789
@@ -117,7 +118,8 @@ fn decode_get_updates_response() {
                     "chat" : {
                         "username" : "test",
                         "id" : 123456789,
-                        "first_name" : "Test"
+                        "first_name" : "Test",
+                        "type": "private"
                     }
                 },
                 "update_id" : 123456789
@@ -135,7 +137,8 @@ fn decode_get_updates_response() {
                     "chat" : {
                         "username" : "test",
                         "id" : 123456789,
-                        "first_name" : "Test"
+                        "first_name" : "Test",
+                        "type": "private"
                     }
                 },
                 "update_id" : 123456790

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -58,6 +58,33 @@ fn decode_group_chat() {
 }
 
 #[test]
+fn decode_supergroup_chat() {
+    use Chat;
+
+    let blob = r#"{"title":"This is a group chat","id":-12345678,"type":"supergroup"}"#;
+    let chat: Chat = json::decode(&blob).unwrap();
+    assert!(chat.is_supergroup());
+}
+
+#[test]
+fn decode_channel_chat() {
+    use Chat;
+
+    let blob = r#"{"title":"This is a group chat","id":-12345678,"type":"channel"}"#;
+    let chat: Chat = json::decode(&blob).unwrap();
+    assert!(chat.is_channel());
+}
+
+#[test]
+fn decode_channel_with_username_chat() {
+    use Chat;
+
+    let blob = r#"{"title":"This is a group chat","id":-12345678,"type":"channel", "username": "foo"}"#;
+    let chat: Chat = json::decode(&blob).unwrap();
+    assert!(chat.is_channel());
+}
+
+#[test]
 fn decode_user_chat() {
     use Chat;
     use User;


### PR DESCRIPTION
Merges:
  - #21 — update Type for Contact;
  - #24 — fix handling of replies to a message, but joins `forward_from` and `forward_date` into a single field `forward`.

Fixes:
  - #19 — update API, mostly, without File and getFile and and inline bots support.;
  - #23 — add supergroup support;
  - #25 — add parse_mode to sendMessage method;
  - #27 — update chat type;
  - fix some compiler warnings.
