### PR TITLE
Update hyper to version 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT"
 exclude = ["deploy.sh"]
 
 [dependencies]
-hyper = "0.7"
+hyper = "0.8"
 rustc-serialize = "0.3"
 url = "0.5"
 multipart = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-bot"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>", "Fedor Gogolev <knsd@knsd.net>"]
 
 description = "A library for creating Telegram bots."
@@ -15,7 +15,7 @@ license = "MIT"
 exclude = ["deploy.sh"]
 
 [dependencies]
-hyper = "0.8"
+hyper = "0.7"
 rustc-serialize = "0.3"
 url = "0.5"
-multipart = "0.3"
+multipart = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,10 +480,10 @@ impl Api {
         let mut req = try!(Multipart::from_request(r));
 
         for &(k, ref v) in p.get_params().into_iter() {
-            req.write_text(k, v);
+            try!(req.write_text(k, v));
         }
 
-        match file {
+        try!(match file {
             SendPath::File(name, path) => {
                 match path.to_str() {
                     Some(p) => req.write_file(&name, p),
@@ -491,7 +491,7 @@ impl Api {
                 }
             },
             SendPath::Id(name, id) => req.write_text(&name, id),
-        };
+        });
 
         // Send request and check if it failed
         let mut resp = try!(req.send());


### PR DESCRIPTION
Hyper 0.8 was released and I had trouble building the 0.4.1 version of telegram-bot.

I beleave the reason is the multipart package, which was changed by hyper.