### PR TITLE
Handle messages with unknown type

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -404,6 +404,7 @@ pub enum MessageType {
     GroupChatCreated,
     SuperGroupChatCreated(GroupToSuperGroupMigration),
     ChannelChatCreated,
+    Unknown,
 }
 
 impl Decodable for MessageType {
@@ -461,8 +462,8 @@ impl Decodable for MessageType {
             return Ok(MessageType::ChannelChatCreated);
         };
 
-        // None of the tested fields is present: This is an error
-        Err(d.error("No field for inferring message type is set"))
+        // None of the tested fields is present.
+        Ok(MessageType::Unknown)
     }
 }
 

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -171,3 +171,38 @@ fn decode_get_updates_response() {
 
     let _: Response<Vec<Update>> = json::decode(&blob).unwrap();
 }
+
+#[test]
+fn test_handle_unknown_message_type() {
+    use Response;
+    use Update;
+    use MessageType;
+
+    let blob = r#"{
+        "result" : [
+            {
+                "message" : {
+                    "foo": "bar",
+                    "from" : {
+                        "username" : "test",
+                        "id" : 123456789,
+                        "first_name" : "Test"
+                    },
+                    "date" : 1437821579,
+                    "message_id" : 78,
+                    "chat" : {
+                        "username" : "test",
+                        "id" : 123456789,
+                        "first_name" : "Test",
+                        "type": "private"
+                    }
+                },
+                "update_id" : 123456789
+            }
+        ],
+        "ok" : true
+    }"#;
+    let response: Response<Vec<Update>> = json::decode(&blob).unwrap();
+    assert_eq!(response.result.unwrap().remove(0).message.unwrap().msg, MessageType::Unknown);
+
+}

--- a/src/types/test.rs
+++ b/src/types/test.rs
@@ -204,5 +204,4 @@ fn test_handle_unknown_message_type() {
     }"#;
     let response: Response<Vec<Update>> = json::decode(&blob).unwrap();
     assert_eq!(response.result.unwrap().remove(0).message.unwrap().msg, MessageType::Unknown);
-
 }


### PR DESCRIPTION
Messages with unknown types leads to bot hanging, so we can treat such messages as unknown and process it in regular way.

Related with: #43 